### PR TITLE
Added cbf

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@
 
 ## Other
 
+- [cbf](https://github.com/joshuatvernon/cbf) - Build custom CLI apps with only a json or yaml file.
 - [rga](https://github.com/phiresky/ripgrep-all) - Ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, etc.
 - [hunter](https://github.com/rabite0/hunter) - Ranger-like file browser written in rust.
 - [gotop](https://github.com/cjbassi/gotop) - Terminal based graphical activity monitor inspired by gtop and vtop.


### PR DESCRIPTION
Added cbf a CLI app for creating custom CLI apps. Very meta but very powerful. It allows developers to create very simple scripts in json or yaml that define how a CLI app will behave. Scripts can be stored in any repo to share with other team members or just stored in cbf directly for personal used. Cbf can also turn any package.json scripts section into a CLI app.