### PR TITLE
Add travis integration with link checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - docker run -ti --rm -v $PWD:/mnt:ro simeg/urlsup `find . -name "*.md"` --threads 10
+


### PR DESCRIPTION
This change will add an integration to Travis CI. Travis will run the
script defined in the script value on every pull request and it won't
pass unless all links respond with 200 OK.

-------------

The drawback with this approach is that in case a link is down, temporarily or permanently, the PR won't be green. Another approach is to have a separate branch on this repo that runs `urlsup` every now and then, and have a badge display the status in the README.

WDYT @nikitavoloboev?